### PR TITLE
Throw on .type() if header is completely missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,10 @@ internals.paramsRegex = /;\s*boundary=(?:"([^"]+)"|([^;"\s]+))/i;
 
 exports.type = function (header) {
 
+    if (!header) {
+        throw Boom.badRequest('Invalid content-type header');
+    }
+
     const match = header.match(internals.contentTypeRegex);
     if (!match) {
         throw Boom.badRequest('Invalid content-type header');

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,11 @@ describe('type()', () => {
         expect(Date.now() - now).to.be.below(100);
     });
 
+    it('errors on missing header', () => {
+
+        expect(() => Content.type()).to.throw();
+    });
+
     it('errors on invalid header', () => {
 
         expect(() => Content.type('application; some')).to.throw();


### PR DESCRIPTION
This adds the same behavior that `.content()` has, where a completely missing header will throw a `Boom` response.

Currently it would throw an exception trying to call `.match` on the nonexistent header.