### PR TITLE
support parsing charset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/node_modules
 **/package-lock.json
+**/yarn.lock
 
 coverage.*
 

--- a/API.md
+++ b/API.md
@@ -5,14 +5,17 @@
 
 ### `type(header)`
 
-Generates an object containing the associated mime-type and the boundary (if specified).
+Generates an object containing the associated mime-type, charset and the boundary (if specified).
 
 ```js
 Content.type('application/json; some=property; and="another"');
 // { mime: 'application/json' }
 
-Content.type('application/json; boundary=asdf');
-// { mime: 'application/json', boundary: 'asdf' }
+Content.type('text/html; charset=utf-8')
+// { mime: 'text/html', charset: 'utf-8' }
+
+Content.type('multipart/form-data; boundary=asdf');
+// { mime: 'multipart/form-data', boundary: 'asdf' }
 ```
 
 If the header is invalid (malformed) or missing required data, such as a `multipart/form-data` header missing its `boundary`, it returns an HTTP `Bad Request` error.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,10 @@ const internals = {};
 internals.contentTypeRegex = /^([^\/\s]+\/[^\s;]+)(.*)?$/;
 
 //                                             1: "b"   2: b
-internals.charsetParamRegex = /;\s*charset=(?:"([^"]+)"|([^;"\s]+))(?!")/i;
+internals.charsetParamRegex = /;\s*charset=(?:"([^"]+)"|([^;"\s]+))/i;
 
 //                                               1: "b"   2: b
-internals.boundaryParamRegex = /;\s*boundary=(?:"([^"]+)"|([^;"\s]+))(?!")/i;
+internals.boundaryParamRegex = /;\s*boundary=(?:"([^"]+)"|([^;"\s]+))/i;
 
 
 exports.type = function (header) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,11 @@ const internals = {};
 //                             1: type/subtype    2: params
 internals.contentTypeRegex = /^([^\/\s]+\/[^\s;]+)(.*)?$/;
 
-//                                        1: "b"   2: b
-internals.paramsRegex = /;\s*boundary=(?:"([^"]+)"|([^;"\s]+))/i;
+//                                             1: "b"   2: b
+internals.charsetParamRegex = /;\s*charset=(?:"([^"]+)"|([^;"\s]+))(?!")/i;
+
+//                                               1: "b"   2: b
+internals.boundaryParamRegex = /;\s*boundary=(?:"([^"]+)"|([^;"\s]+))(?!")/i;
 
 
 exports.type = function (header) {
@@ -37,10 +40,17 @@ exports.type = function (header) {
         mime: match[1].toLowerCase()
     };
 
+    const params = match[2];
+    if (params) {
+        const param = params.match(internals.charsetParamRegex);
+        if (param) {
+            result.charset = (param[1] || param[2]).toLowerCase();
+        }
+    }
+
     if (result.mime.indexOf('multipart/') === 0) {
-        const params = match[2];
         if (params) {
-            const param = params.match(internals.paramsRegex);
+            const param = params.match(internals.boundaryParamRegex);
             if (param) {
                 result.boundary = param[1] || param[2];
             }

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,43 @@ describe('type()', () => {
         expect(type.boundary).to.equal('abcdefghijklm');
     });
 
+    it('parses header (charset)', () => {
+
+        const type = Content.type('application/json; charset=utf-8');
+        expect(type.mime).to.equal('application/json');
+        expect(type.charset).to.equal('utf-8');
+    });
+
+    it('parses header (quoted charset)', () => {
+
+        const type = Content.type('application/json; charset="iso-8859-1"');
+        expect(type.mime).to.equal('application/json');
+        expect(type.charset).to.equal('iso-8859-1');
+    });
+
+    it('parses header (charset and boundary)', () => {
+
+        const type = Content.type('multipart/form-data; charset=utf-8; boundary=abcdefghijklm');
+        expect(type.mime).to.equal('multipart/form-data');
+        expect(type.charset).to.equal('utf-8');
+        expect(type.boundary).to.equal('abcdefghijklm');
+    });
+
+    it('parses header (boundary and charset)', () => {
+
+        const type = Content.type('multipart/form-data; boundary=abcdefghijklm; charset=utf-8');
+        expect(type.mime).to.equal('multipart/form-data');
+        expect(type.charset).to.equal('utf-8');
+        expect(type.boundary).to.equal('abcdefghijklm');
+    });
+
+    it('parses header (uppercase)', () => {
+
+        const type = Content.type('TEXT/HTML; CHARSET=EUC-KR');
+        expect(type.mime).to.equal('text/html');
+        expect(type.charset).to.equal('euc-kr');
+    });
+
     it('handles large number of OWS', () => {
 
         const now = Date.now();
@@ -78,7 +115,15 @@ describe('type()', () => {
 
     it('handles multiple boundary params', () => {
 
-        const header = '0/\\x00;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#;boundary=#"';
+        const header = `multipart/form-data ${new Array(80000).join(';boundary=#')}`;
+        const now = Date.now();
+        Content.type(header);
+        expect(Date.now() - now).to.be.below(100);
+    });
+
+    it('handles multiple charset params', () => {
+
+        const header = `text/plain ${new Array(80000).join(';charset=utf-8')}`;
         const now = Date.now();
         Content.type(header);
         expect(Date.now() - now).to.be.below(100);


### PR DESCRIPTION
Add support for parsing `charset` directive in `Content-Type` header.

It seems `Content-Type` with both `charset` and `boundary` is not specified in the RFC 7231 or may be invalid. The current implementation parses and provides both of them anyway if specified.

Related: https://github.com/hapijs/subtext/issues/95