### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x"
+    "@hapi/boom": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Content;
+
+    before(async () => {
+
+        Content = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Content)).to.equal([
+            'default',
+            'disposition',
+            'type'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of hapi modules.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as content v6.